### PR TITLE
fix(today-widget): Wrong name being displayed during school weeks

### DIFF
--- a/src/screens/smu/components/widget/TodaySummary/components/TodayEvent.tsx
+++ b/src/screens/smu/components/widget/TodaySummary/components/TodayEvent.tsx
@@ -84,7 +84,7 @@ const TodayEvent: React.FC<Props> = function (props) {
     if (isVacation) {
       const isLastDay = endDate.diff(today, 'days') === 0;
       return {
-        type: currentEvent.type.toUpperCase(),
+        type: currentEvent.type,
         title: isLastDay
           ? 'LAST DAY'
           : `DAY ${today.diff(startDate, 'days') + 1}`,
@@ -112,24 +112,24 @@ const TodayEvent: React.FC<Props> = function (props) {
       return <TodayEventLoading />;
     }
 
-    if (event.type === 'VACATION') {
+    if (event.type === 'vacation') {
       return (
-        <DaysWrapper>
-          <h1>{event?.title}</h1>
-          <span>OF</span>
-        </DaysWrapper>
+        <>
+          <DaysWrapper>
+            <h1>{event?.title}</h1>
+            <span>OF</span>
+          </DaysWrapper>
+          <HighlightText>{event.type.toUpperCase()}</HighlightText>
+        </>
       );
     }
 
-    return null;
+    return <HighlightText>{event.title}</HighlightText>;
   }, [event]);
 
   return (
     <Wrapper>
-      <EventWrapper>
-        {renderContents}
-        {event?.type != null && <HighlightText>{event.type}</HighlightText>}
-      </EventWrapper>
+      <EventWrapper>{renderContents}</EventWrapper>
       <CustomLink href="/smu/calendar">
         <Icon name="open_in_full" />
       </CustomLink>

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -32,7 +32,7 @@ declare namespace App {
     }
 
     interface CurrentEvent {
-      type: SchoolPeriodType;
+      type: PeriodType;
       date_start: string;
       date_end: string;
       week_no?: number;


### PR DESCRIPTION
## Purpose

This PR fixes the wrong name being displayed during a school week as the wrong event string is being returned.